### PR TITLE
Fix MCP postinstall paths

### DIFF
--- a/.dev/tools/postinstall-build-mcp.js
+++ b/.dev/tools/postinstall-build-mcp.js
@@ -12,14 +12,14 @@
 const { existsSync, mkdirSync, readdirSync, copyFileSync } = require('node:fs');
 const path = require('node:path');
 
-const rootDir = path.resolve(__dirname, '..');
+const rootDir = path.resolve(__dirname, '..', '..');
 const distMcpDir = path.join(rootDir, 'dist', 'mcp');
-const serverEntry = path.join(distMcpDir, 'mcp', 'server.js');
+const serverEntry = path.join(distMcpDir, 'server.js');
 
 const hasPrebuiltServer = existsSync(serverEntry);
 
 if (!hasPrebuiltServer) {
-  console.warn('⚠️  Prebuilt MCP server not found at dist/mcp/mcp/server.js.');
+  console.warn('⚠️  Prebuilt MCP server not found at dist/mcp/server.js.');
   console.warn('    Skipping MCP asset sync. Run "npm run build:mcp" to generate the build.');
   process.exit(0);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aidesigner",
-  "version": "1.3.24",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aidesigner",
-      "version": "1.3.24",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- resolve the MCP postinstall script paths from the package root so asset copies target the right folders
- update the prebuilt server check to look for dist/mcp/server.js
- refresh package-lock metadata after running npm install to verify the MCP assets copy

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68e348b8c288832699fb3fb9000a47ce