### PR TITLE
Rename bridge module to AidesignerBridge

### DIFF
--- a/.dev/lib/aidesigner-bridge.js
+++ b/.dev/lib/aidesigner-bridge.js
@@ -33,7 +33,7 @@ function resolvePackageRoot() {
   // Fallback: assume package root is two levels up from __dirname
   const fallbackPath = path.resolve(__dirname, '..', '..');
   console.warn(
-    `[aidesignerBridge] Warning: No package.json found in directory tree. Falling back to ${fallbackPath}`,
+    `[AidesignerBridge] Warning: No package.json found in directory tree. Falling back to ${fallbackPath}`,
   );
   return fallbackPath;
 }
@@ -59,7 +59,7 @@ function resolveDefaultV6Path(rootDirectory) {
   }
 
   console.warn(
-    `[aidesignerBridge] Warning: No V6 modules found in candidates: ${candidates.join(', ')}`,
+    `[AidesignerBridge] Warning: No V6 modules found in candidates: ${candidates.join(', ')}`,
   );
   return null;
 }
@@ -108,9 +108,9 @@ function arrayify(value) {
   return [value];
 }
 
-class aidesignerBridge {
+class AidesignerBridge {
   /**
-   * Creates a new aidesignerBridge instance
+   * Creates a new AidesignerBridge instance
    * @param {Object} options - Configuration options
    * @param {string} [options.aidesignerCorePath] - Path to aidesigner-core directory
    * @param {string} [options.aidesignerV6Path] - Path to v6 modules directory
@@ -215,7 +215,7 @@ class aidesignerBridge {
       const candidatePath = path.join(basePath, `${agentId}.md`);
 
       if (await fs.pathExists(candidatePath)) {
-        console.debug(`[aidesignerBridge] Found agent '${agentId}' at: ${candidatePath}`);
+        console.debug(`[AidesignerBridge] Found agent '${agentId}' at: ${candidatePath}`);
         resolvedAgentPath = candidatePath;
         break;
       }
@@ -317,7 +317,7 @@ class aidesignerBridge {
           return path.resolve(candidate);
         } catch (error) {
           console.warn(
-            `[aidesignerBridge] Skipping invalid agent search path: ${candidate}`,
+            `[AidesignerBridge] Skipping invalid agent search path: ${candidate}`,
             error,
           );
           return null;
@@ -794,4 +794,4 @@ class aidesignerBridge {
   }
 }
 
-module.exports = { aidesignerBridge };
+module.exports = { AidesignerBridge };

--- a/.dev/lib/deliverable-generator.js
+++ b/.dev/lib/deliverable-generator.js
@@ -5,14 +5,14 @@
 
 const fs = require('fs-extra');
 const path = require('node:path');
-const { aidesignerBridge } = require('./aidesigner-bridge');
+const { AidesignerBridge } = require('./aidesigner-bridge');
 
 class DeliverableGenerator {
   constructor(projectPath = process.cwd(), options = {}) {
     this.projectPath = projectPath;
     this.docsPath = path.join(projectPath, 'docs');
     this.aidesignerBridge =
-      options.aidesignerBridge || options.bmadBridge || new aidesignerBridge();
+      options.aidesignerBridge || options.bmadBridge || new AidesignerBridge();
 
     /** @type {Map<number, Promise<any>>} */
     this.epicSpecCache = new Map();

--- a/.dev/lib/story-context-validator.js
+++ b/.dev/lib/story-context-validator.js
@@ -55,7 +55,7 @@ function hasBody(section) {
 async function runStoryContextValidation({
   projectState,
   createLLMClient,
-  aidesignerBridge,
+  AidesignerBridge,
   lane = 'review',
   notes,
   trigger,
@@ -68,12 +68,12 @@ async function runStoryContextValidation({
   if (typeof createLLMClient !== 'function') {
     throw new TypeError('createLLMClient function is required');
   }
-  if (typeof aidesignerBridge !== 'function') {
-    throw new TypeError('aidesignerBridge constructor is required');
+  if (typeof AidesignerBridge !== 'function') {
+    throw new TypeError('AidesignerBridge constructor is required');
   }
 
   const llmClient = await createLLMClient(lane);
-  const bridge = new aidesignerBridge({ llmClient });
+  const bridge = new AidesignerBridge({ llmClient });
 
   if (typeof bridge.initialize === 'function') {
     await bridge.initialize();

--- a/.dev/src/mcp-server/runtime.ts
+++ b/.dev/src/mcp-server/runtime.ts
@@ -1486,7 +1486,7 @@ export async function runOrchestratorServer(
           });
 
           const reviewLLM = await createLLMClient(lane);
-          const reviewBridge = new aidesignerBridge({ llmClient: reviewLLM });
+          const reviewBridge = new AidesignerBridge({ llmClient: reviewLLM });
           await reviewBridge.initialize();
 
           const projectSnapshot = projectState.exportForLLM();

--- a/.dev/src/v6-poc/modules/invisible/module.ts
+++ b/.dev/src/v6-poc/modules/invisible/module.ts
@@ -39,18 +39,18 @@ export async function probeInvisibleModule(context: V6ModuleContext): Promise<Co
 
   // 2. Attempt to reuse the CommonJS aidesigner bridge inside an ESM-oriented runtime.
   try {
-    const { aidesignerBridge } = require(path.join(context.legacyRoot, "lib", "aidesigner-bridge.js"));
-    const bridge = new aidesignerBridge();
+    const { AidesignerBridge } = require(path.join(context.legacyRoot, "lib", "aidesigner-bridge.js"));
+    const bridge = new AidesignerBridge();
     if (typeof bridge.initialize !== "function") {
-      blockers.push("aidesignerBridge.initialize is not available after require() shim.");
+      blockers.push("AidesignerBridge.initialize is not available after require() shim.");
     } else {
       warnings.push(
-        "aidesignerBridge loads via CommonJS require(); V6 default ESM bundler will need a compatibility shim or rewrite."
+        "AidesignerBridge loads via CommonJS require(); V6 default ESM bundler will need a compatibility shim or rewrite."
       );
     }
   } catch (error) {
     blockers.push(
-      `Failed to require legacy aidesigner bridge: ${(error as Error).message}. ` +
+      `Failed to require legacy AidesignerBridge: ${(error as Error).message}. ` +
         "V6 loaders refuse CommonJS modules without explicit compatibility wrappers."
     );
   }

--- a/.dev/test/aidesigner-bridge.legacy-core.test.js
+++ b/.dev/test/aidesigner-bridge.legacy-core.test.js
@@ -5,11 +5,11 @@ const os = require('node:os');
 
 jest.mock('../hooks/context-enrichment', () => ({}), { virtual: true });
 
-const { aidesignerBridge } = require('../lib/aidesigner-bridge.js');
+const { AidesignerBridge } = require('../lib/aidesigner-bridge.js');
 
-describe('aidesignerBridge legacy core detection', () => {
+describe('AidesignerBridge legacy core detection', () => {
   test('initializes from package root using default paths', async () => {
-    const bridge = new aidesignerBridge({ llmClient: { chat: jest.fn() } });
+    const bridge = new AidesignerBridge({ llmClient: { chat: jest.fn() } });
 
     const config = await bridge.initialize();
 
@@ -29,7 +29,7 @@ describe('aidesignerBridge legacy core detection', () => {
     const packageRoot = path.resolve(__dirname, '..', '..');
     const customPath = path.join(packageRoot, 'aidesigner-core');
 
-    const bridge = new aidesignerBridge({
+    const bridge = new AidesignerBridge({
       aidesignerCorePath: customPath,
       llmClient: { chat: jest.fn() },
     });
@@ -54,7 +54,7 @@ describe('aidesignerBridge legacy core detection', () => {
       const agentContent = `# Test Agent\n\n\`\`\`yaml\nagent:\n  id: test-agent\n  name: Test Agent\n\`\`\`\n\nTest content.`;
       await fs.writeFile(path.join(modulesRoot, 'agents', 'test-agent.md'), agentContent, 'utf8');
 
-      const bridge = new aidesignerBridge({
+      const bridge = new AidesignerBridge({
         aidesignerCorePath: path.join(tempRoot, 'missing-core'),
         aidesignerV6Path: path.join(tempRoot, 'bmad'),
         llmClient: { chat: jest.fn() },
@@ -73,7 +73,7 @@ describe('aidesignerBridge legacy core detection', () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aidesigner-empty-test-'));
 
     try {
-      const bridge = new aidesignerBridge({
+      const bridge = new AidesignerBridge({
         aidesignerCorePath: path.join(tempRoot, 'missing-core'),
         aidesignerV6Path: path.join(tempRoot, 'missing-v6'),
         llmClient: { chat: jest.fn() },

--- a/.dev/test/aidesigner-bridge.v6-mode.test.js
+++ b/.dev/test/aidesigner-bridge.v6-mode.test.js
@@ -4,7 +4,7 @@ const path = require('node:path');
 
 jest.mock('../hooks/context-enrichment', () => ({}), { virtual: true });
 
-const { aidesignerBridge } = require('../lib/aidesigner-bridge.js');
+const { AidesignerBridge } = require('../lib/aidesigner-bridge.js');
 
 async function createV6Workspace() {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aidesigner-v6-workspace-'));
@@ -26,7 +26,7 @@ async function createV6Workspace() {
   return tempRoot;
 }
 
-describe('aidesignerBridge V6 module detection', () => {
+describe('AidesignerBridge V6 module detection', () => {
   let tempRoot;
   let pathExistsSpy;
   let readFileSpy;
@@ -72,7 +72,7 @@ describe('aidesignerBridge V6 module detection', () => {
       throw new Error(`Unexpected readFile access during test: ${targetPath}`);
     });
 
-    const bridge = new aidesignerBridge({
+    const bridge = new AidesignerBridge({
       aidesignerCorePath: path.join(tempRoot, 'missing-core'),
       aidesignerV6Path: tempRoot,
       llmClient: { chat: jest.fn() },

--- a/.dev/test/phase-transition.agent-loading.test.js
+++ b/.dev/test/phase-transition.agent-loading.test.js
@@ -2,11 +2,11 @@ const path = require('node:path');
 
 jest.mock('../hooks/context-enrichment', () => ({}), { virtual: true });
 
-const { aidesignerBridge } = require('../lib/aidesigner-bridge.js');
+const { AidesignerBridge } = require('../lib/aidesigner-bridge.js');
 
 describe('phase transition legacy agent loading', () => {
   test('phase-detector agent resolves from fallback search path', async () => {
-    const bridge = new aidesignerBridge({ llmClient: { chat: jest.fn() } });
+    const bridge = new AidesignerBridge({ llmClient: { chat: jest.fn() } });
 
     await bridge.initialize();
 

--- a/.dev/test/run-orchestrator-server.integration.test.js
+++ b/.dev/test/run-orchestrator-server.integration.test.js
@@ -126,7 +126,7 @@ const mockListAgents = jest.fn();
 const mockGetEnvironmentInfo = jest.fn();
 
 jest.mock('../lib/aidesigner-bridge.js', () => {
-  const aidesignerBridge = jest.fn().mockImplementation(() => ({
+  const AidesignerBridge = jest.fn().mockImplementation(() => ({
     initialize: mockBridgeInitialize,
     getEnvironmentInfo: mockGetEnvironmentInfo,
     runAgent: mockRunAgent,
@@ -136,7 +136,7 @@ jest.mock('../lib/aidesigner-bridge.js', () => {
   }));
 
   return {
-    aidesignerBridge,
+    AidesignerBridge,
     __bridgeMocks: {
       initializeMock: mockBridgeInitialize,
       runAgentMock: mockRunAgent,

--- a/.dev/test/story-context-validation.test.js
+++ b/.dev/test/story-context-validation.test.js
@@ -83,7 +83,7 @@ describe('story context validation helper', () => {
     const result = await runStoryContextValidation({
       projectState,
       createLLMClient: async () => ({ lane: 'review' }),
-      aidesignerBridge: FakeBridge,
+      AidesignerBridge: FakeBridge,
       notes: 'smoke test',
       trigger: 'unit_test',
     });
@@ -113,7 +113,7 @@ describe('story context validation helper', () => {
     const result = await runStoryContextValidation({
       projectState,
       createLLMClient: async () => ({ lane: 'review' }),
-      aidesignerBridge: FakeBridge,
+      AidesignerBridge: FakeBridge,
     });
 
     expect(result.status).toBe('block');
@@ -141,7 +141,7 @@ describe('story context validation helper', () => {
       ensureStoryContextReadyForDevelopment({
         projectState,
         createLLMClient: async () => ({ lane: 'review' }),
-        aidesignerBridge: FakeBridge,
+        AidesignerBridge: FakeBridge,
       }),
     ).rejects.toMatchObject({
       message: expect.stringContaining('Story context validation failed'),

--- a/.dev/test/v6-codex-compat.test.js
+++ b/.dev/test/v6-codex-compat.test.js
@@ -3,7 +3,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { executeAutoCommand } = require('../lib/auto-commands.js');
-const { aidesignerBridge } = require('../lib/aidesigner-bridge.js');
+const { AidesignerBridge } = require('../lib/aidesigner-bridge.js');
 const { DeliverableGenerator } = require('../lib/deliverable-generator.js');
 const { ProjectState } = require('../lib/project-state.js');
 const { QuickLane } = require('../lib/quick-lane.js');
@@ -96,7 +96,7 @@ describe('Codex CLI V6 sandbox compatibility', () => {
     tempDirs.push(tempDir);
 
     const stubLLM = new StubLLMClient('Mock agent output for planning');
-    const bridge = new aidesignerBridge({ llmClient: stubLLM });
+    const bridge = new AidesignerBridge({ llmClient: stubLLM });
     await bridge.initialize();
 
     const autoResult = await executeAutoCommand(

--- a/.dev/test/v6-module-probe.test.ts
+++ b/.dev/test/v6-module-probe.test.ts
@@ -49,7 +49,7 @@ describe('probeInvisibleModule', () => {
             return initializeMock();
           }
         }
-        return { aidesignerBridge: MockBridge };
+        return { AidesignerBridge: MockBridge };
       }
       throw new Error(`Unexpected require path: ${requestedPath}`);
     });
@@ -81,7 +81,7 @@ describe('probeInvisibleModule', () => {
     expect(result.blockers).toHaveLength(1);
     expect(result.blockers[0]).toMatch(/Failed to import MCP runtime as ESM:.*TypeScript compilation currently targets CommonJS paths, incompatible with V6's native ES build\./);
     expect(result.warnings).toEqual([
-      'aidesignerBridge loads via CommonJS require(); V6 default ESM bundler will need a compatibility shim or rewrite.',
+      'AidesignerBridge loads via CommonJS require(); V6 default ESM bundler will need a compatibility shim or rewrite.',
     ]);
     expect(result.notes).toEqual([
       `Found candidate module directory at ${expectedModuleDir}.`,
@@ -144,7 +144,7 @@ describe('probeInvisibleModule', () => {
     // The important check is the result, not the exact error messages
     expect(result.blockers).toHaveLength(4);
     expect(result.blockers[0]).toBe(`Missing module slot: expected directory at ${expectedModuleDir}. V6 alpha currently ships only BMM/BMB/CIS modules, so invisible orchestration needs a new module registration point.`);
-    expect(result.blockers[1]).toBe('Failed to require legacy aidesigner bridge: CommonJS module rejection. V6 loaders refuse CommonJS modules without explicit compatibility wrappers.');
+    expect(result.blockers[1]).toBe('Failed to require legacy AidesignerBridge: CommonJS module rejection. V6 loaders refuse CommonJS modules without explicit compatibility wrappers.');
     expect(result.blockers[2]).toMatch(/Failed to import MCP runtime as ESM:.*TypeScript compilation currently targets CommonJS paths, incompatible with V6's native ES build\./);
     expect(result.blockers[3]).toBe(`aidesigner orchestrator persona missing at ${personaPath}.`);
     expect(result.warnings).toEqual([]);


### PR DESCRIPTION
## Summary
- rename the MCP bridge module to `aidesigner-bridge` and export `AidesignerBridge`
- update dependent libraries, runtime wiring, and tests to use the new class name
- refresh probe messaging to reference the capitalized bridge name

## Testing
- npm run build:mcp
- npm test -- aidesigner-bridge

------
https://chatgpt.com/codex/tasks/task_e_68e348c6b7588326a2f4b976bd5e7603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the bridge name to “AidesignerBridge” across the app, updating logs and user-facing messages for consistency. Note: integrations should use the new exported name.

* **Tests**
  * Updated test suites and mocks to reference “AidesignerBridge”; no behavioral changes.

* **Chores**
  * Adjusted runtime checks and copy to reflect the new naming, improving clarity in warnings and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->