### PR TITLE
Add Momentum Snapshot executive overview to PRD template

### DIFF
--- a/aidesigner-core/templates/prd-tmpl.yaml
+++ b/aidesigner-core/templates/prd-tmpl.yaml
@@ -13,6 +13,20 @@ workflow:
   elicitation: advanced-elicitation
 
 sections:
+  - id: executive-overview
+    title: Momentum Snapshot
+    type: table
+    columns: [Focus, Details]
+    instruction: |
+      Generate a fast-scanning executive overview before deeper sections. Populate the table with:
+
+      - 🎯 Project Goal — summarize the current north star. Auto-fill using the latest Project Brief (docs/project-brief.md) or recently approved outcomes in the Decisions log if available.
+      - 🧑‍🤝‍🧑 Primary Users — identify the main personas or segments. Pull directly from the Project Brief or user research artifacts when supplied.
+      - 🚦 Current Phase — indicate the product development phase inferred from the latest decisions, roadmap milestones, or phase detector insights.
+      - ➡️ Recommended Next Move — state the single action that keeps momentum (e.g., unblock dependency, validate assumption, advance to next workflow stage). Cite the artifact or conversation that informs the recommendation.
+      - ⚠️ Assumptions to Confirm — explicitly list any guesses or incomplete data surfaced while preparing the snapshot. Highlight them with **Assumption – Needs Confirmation** so reviewers can respond immediately.
+
+      Always cross-reference existing documents before asking new questions. If data is missing, mark the gap as an assumption and clarify what validation is required in the snapshot.
   - id: goals-context
     title: Goals and Background Context
     instruction: |

--- a/dist/agents/bmad-master.txt
+++ b/dist/agents/bmad-master.txt
@@ -5574,6 +5574,20 @@ workflow:
   elicitation: advanced-elicitation
 
 sections:
+  - id: executive-overview
+    title: Momentum Snapshot
+    type: table
+    columns: [Focus, Details]
+    instruction: |
+      Generate a fast-scanning executive overview before deeper sections. Populate the table with:
+
+      - 🎯 Project Goal — summarize the current north star. Auto-fill using the latest Project Brief (docs/project-brief.md) or recently approved outcomes in the Decisions log if available.
+      - 🧑‍🤝‍🧑 Primary Users — identify the main personas or segments. Pull directly from the Project Brief or user research artifacts when supplied.
+      - 🚦 Current Phase — indicate the product development phase inferred from the latest decisions, roadmap milestones, or phase detector insights.
+      - ➡️ Recommended Next Move — state the single action that keeps momentum (e.g., unblock dependency, validate assumption, advance to next workflow stage). Cite the artifact or conversation that informs the recommendation.
+      - ⚠️ Assumptions to Confirm — explicitly list any guesses or incomplete data surfaced while preparing the snapshot. Highlight them with **Assumption – Needs Confirmation** so reviewers can respond immediately.
+
+      Always cross-reference existing documents before asking new questions. If data is missing, mark the gap as an assumption and clarify what validation is required in the snapshot.
   - id: goals-context
     title: Goals and Background Context
     instruction: |

--- a/dist/agents/pm.txt
+++ b/dist/agents/pm.txt
@@ -1465,6 +1465,20 @@ workflow:
   elicitation: advanced-elicitation
 
 sections:
+  - id: executive-overview
+    title: Momentum Snapshot
+    type: table
+    columns: [Focus, Details]
+    instruction: |
+      Generate a fast-scanning executive overview before deeper sections. Populate the table with:
+
+      - 🎯 Project Goal — summarize the current north star. Auto-fill using the latest Project Brief (docs/project-brief.md) or recently approved outcomes in the Decisions log if available.
+      - 🧑‍🤝‍🧑 Primary Users — identify the main personas or segments. Pull directly from the Project Brief or user research artifacts when supplied.
+      - 🚦 Current Phase — indicate the product development phase inferred from the latest decisions, roadmap milestones, or phase detector insights.
+      - ➡️ Recommended Next Move — state the single action that keeps momentum (e.g., unblock dependency, validate assumption, advance to next workflow stage). Cite the artifact or conversation that informs the recommendation.
+      - ⚠️ Assumptions to Confirm — explicitly list any guesses or incomplete data surfaced while preparing the snapshot. Highlight them with **Assumption – Needs Confirmation** so reviewers can respond immediately.
+
+      Always cross-reference existing documents before asking new questions. If data is missing, mark the gap as an assumption and clarify what validation is required in the snapshot.
   - id: goals-context
     title: Goals and Background Context
     instruction: |

--- a/dist/teams/team-all.txt
+++ b/dist/teams/team-all.txt
@@ -8635,6 +8635,20 @@ workflow:
   elicitation: advanced-elicitation
 
 sections:
+  - id: executive-overview
+    title: Momentum Snapshot
+    type: table
+    columns: [Focus, Details]
+    instruction: |
+      Generate a fast-scanning executive overview before deeper sections. Populate the table with:
+
+      - 🎯 Project Goal — summarize the current north star. Auto-fill using the latest Project Brief (docs/project-brief.md) or recently approved outcomes in the Decisions log if available.
+      - 🧑‍🤝‍🧑 Primary Users — identify the main personas or segments. Pull directly from the Project Brief or user research artifacts when supplied.
+      - 🚦 Current Phase — indicate the product development phase inferred from the latest decisions, roadmap milestones, or phase detector insights.
+      - ➡️ Recommended Next Move — state the single action that keeps momentum (e.g., unblock dependency, validate assumption, advance to next workflow stage). Cite the artifact or conversation that informs the recommendation.
+      - ⚠️ Assumptions to Confirm — explicitly list any guesses or incomplete data surfaced while preparing the snapshot. Highlight them with **Assumption – Needs Confirmation** so reviewers can respond immediately.
+
+      Always cross-reference existing documents before asking new questions. If data is missing, mark the gap as an assumption and clarify what validation is required in the snapshot.
   - id: goals-context
     title: Goals and Background Context
     instruction: |

--- a/dist/teams/team-fullstack.txt
+++ b/dist/teams/team-fullstack.txt
@@ -4578,6 +4578,20 @@ workflow:
   elicitation: advanced-elicitation
 
 sections:
+  - id: executive-overview
+    title: Momentum Snapshot
+    type: table
+    columns: [Focus, Details]
+    instruction: |
+      Generate a fast-scanning executive overview before deeper sections. Populate the table with:
+
+      - 🎯 Project Goal — summarize the current north star. Auto-fill using the latest Project Brief (docs/project-brief.md) or recently approved outcomes in the Decisions log if available.
+      - 🧑‍🤝‍🧑 Primary Users — identify the main personas or segments. Pull directly from the Project Brief or user research artifacts when supplied.
+      - 🚦 Current Phase — indicate the product development phase inferred from the latest decisions, roadmap milestones, or phase detector insights.
+      - ➡️ Recommended Next Move — state the single action that keeps momentum (e.g., unblock dependency, validate assumption, advance to next workflow stage). Cite the artifact or conversation that informs the recommendation.
+      - ⚠️ Assumptions to Confirm — explicitly list any guesses or incomplete data surfaced while preparing the snapshot. Highlight them with **Assumption – Needs Confirmation** so reviewers can respond immediately.
+
+      Always cross-reference existing documents before asking new questions. If data is missing, mark the gap as an assumption and clarify what validation is required in the snapshot.
   - id: goals-context
     title: Goals and Background Context
     instruction: |

--- a/dist/teams/team-no-ui.txt
+++ b/dist/teams/team-no-ui.txt
@@ -4524,6 +4524,20 @@ workflow:
   elicitation: advanced-elicitation
 
 sections:
+  - id: executive-overview
+    title: Momentum Snapshot
+    type: table
+    columns: [Focus, Details]
+    instruction: |
+      Generate a fast-scanning executive overview before deeper sections. Populate the table with:
+
+      - 🎯 Project Goal — summarize the current north star. Auto-fill using the latest Project Brief (docs/project-brief.md) or recently approved outcomes in the Decisions log if available.
+      - 🧑‍🤝‍🧑 Primary Users — identify the main personas or segments. Pull directly from the Project Brief or user research artifacts when supplied.
+      - 🚦 Current Phase — indicate the product development phase inferred from the latest decisions, roadmap milestones, or phase detector insights.
+      - ➡️ Recommended Next Move — state the single action that keeps momentum (e.g., unblock dependency, validate assumption, advance to next workflow stage). Cite the artifact or conversation that informs the recommendation.
+      - ⚠️ Assumptions to Confirm — explicitly list any guesses or incomplete data surfaced while preparing the snapshot. Highlight them with **Assumption – Needs Confirmation** so reviewers can respond immediately.
+
+      Always cross-reference existing documents before asking new questions. If data is missing, mark the gap as an assumption and clarify what validation is required in the snapshot.
   - id: goals-context
     title: Goals and Background Context
     instruction: |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -93,6 +93,18 @@ QA Assessments   → docs/qa/assessments/
 QA Gates         → docs/qa/gates/
 ```
 
+#### Momentum Snapshot (Executive Overview)
+
+Every PRD generated with the core template now opens with a **Momentum Snapshot** table. This quick-read header is designed for executive reviews and daily stand-ups:
+
+- 🎯 **Project Goal** — auto-filled from the latest Project Brief or documented decisions so the current north star is immediately visible.
+- 🧑‍🤝‍🧑 **Primary Users** — pulls personas from the brief or any attached research to keep empathy front-and-center.
+- 🚦 **Current Phase** — reflects where the product sits in the lifecycle based on recent approvals or the phase detector.
+- ➡️ **Recommended Next Move** — identifies the single action that keeps momentum, citing the artifact or conversation that backs the recommendation.
+- ⚠️ **Assumptions to Confirm** — clearly labels any guessed or missing data with “**Assumption – Needs Confirmation**,” helping reviewers decide what to validate first.
+
+Before asking new questions, the PM agent cross-references the Project Brief, Decision Log, and other uploaded artifacts to pre-populate the snapshot. Any uncertainty is surfaced as an explicit assumption so stakeholders know exactly what requires confirmation.
+
 #### Targeted Epic Specs (Next-Incomplete Focus)
 
 - Run the Architect command `cmd tech-spec` whenever you're ready to advance an epic.


### PR DESCRIPTION
## Summary
- add a Momentum Snapshot executive overview section to the PRD template to surface goals, users, phase, next move, and assumptions
- propagate the updated section to bundled agent and team instruction files so downstream generators stay aligned
- document the new quick-read header in the user guide for reviewers

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e35fcc9150832699d9e684f9329d2c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Momentum Snapshot (Executive Overview) to the PRD template, providing a concise table with key fields (Project Goal, Primary Users, Current Phase, Recommended Next Move, Assumptions to Confirm).
  - Includes guidance to cross-reference existing artifacts and flag assumptions for missing data.
- Documentation
  - Updated user guide with details on the Momentum Snapshot, its purpose, fields, placement in PRDs, and how it is populated from existing planning artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->