### PR TITLE
Enhance UI prompt defaults with Chrome MCP evidence

### DIFF
--- a/aidesigner-core/tasks/generate-ui-designer-prompt.md
+++ b/aidesigner-core/tasks/generate-ui-designer-prompt.md
@@ -84,50 +84,74 @@ const discoveryState = {
 
 **If Quick Lane (auto-inference):**
 
-Accept pre-populated context passed from Quick Lane engine:
+Accept pre-populated context passed from Quick Lane engine **and attempt to hydrate it with stored Chrome MCP artifacts before falling back to SaaS defaults**:
 
 ```javascript
 const quickLaneContext = {
   productName: "TaskFlow Pro",
   projectDescription: "Collaborative task management",
   journeySteps: [...], // Inferred from PRD
-  brandPalette: {...},  // Defaults or from UX spec
-  typography: {...},    // Defaults
+  chromeMcpEvidence: loadEvidence('docs/ui/chrome-mcp/*.json'),
+  brandPalette: {...},  // May be replaced by synthesized preset
+  typography: {...},    // May be replaced by synthesized preset
+  layoutSystem: {...},  // May be replaced by synthesized preset
   // ... Quick Lane sensible defaults
 }
 ```
 
+> 🔍 **Evidence-first fallback:** Always inspect `chromeMcpEvidence` (or `referenceAssets[].chromeMcpArtifacts`) for CSS variables, extracted palettes, font families, and spacing scales. Only revert to the generic SaaS defaults if **no usable evidence** is available after synthesis.
+
 ### Step 2: Prepare Visual System Context
 
-Consolidate the visual system into reusable tokens:
+1. **Aggregate Chrome MCP evidence** (if present) into a synthesized preset.
+2. **Blend multiple references** to reinforce recurring patterns.
+3. **Only fall back to SaaS defaults** if neither the discovery state nor Chrome MCP evidence provides usable tokens.
 
 ```javascript
+const { packs: evidencePacks, summary: blendSummary } = collectEvidence({
+  chromeMcpEvidence,
+  referenceAssets,
+  discoveryDefaults: { brandPalette, typography, layoutSystem },
+});
+
+const synthesizedPreset = synthesizePreset(evidencePacks, blendSummary);
+
+const {
+  brandPalette: resolvedPalette,
+  typography: resolvedTypography,
+  layoutSystem: resolvedLayout,
+  illustrationStyle: resolvedIllustration,
+  motionNotes: resolvedMotion,
+  confidenceNotes,
+  evidenceTrail,
+} = synthesizedPreset;
+
 const visualSystem = {
-  brandPaletteColors: `${brandPalette.primary}, ${brandPalette.accent}, ${brandPalette.neutral}`,
+  brandPaletteColors: `${resolvedPalette.primary}, ${resolvedPalette.accent}, ${resolvedPalette.neutral}`,
 
   cssVariables: `
---color-primary: ${brandPalette.primary};
---color-accent: ${brandPalette.accent};
---color-neutral: ${brandPalette.neutral};
---font-heading: ${typography.headingFont};
---font-body: ${typography.bodyFont};
---space-base: ${layoutSystem.spacingBase};
-${generateSpacingTokens(layoutSystem.spacingScale)}
+${formatCssBlock(resolvedPalette.cssVariables, resolvedTypography.cssVariables, resolvedLayout.cssVariables)}
   `.trim(),
 
-  headingFont: typography.headingFont,
-  bodyFont: typography.bodyFont,
-  fontScale: `${typography.scale.body} body, ${typography.scale.subtitle} subtitle, ${typography.scale.heading} heading`,
+  headingFont: resolvedTypography.headingFont,
+  bodyFont: resolvedTypography.bodyFont,
+  fontScale: `${resolvedTypography.scale.body} body, ${resolvedTypography.scale.subtitle} subtitle, ${resolvedTypography.scale.heading} heading`,
 
-  layoutStructure: layoutSystem.structure,
-  spacingTokens: layoutSystem.spacingScale.join(', ') + 'px',
-  containerMaxWidth: layoutSystem.maxWidth,
-  gridPattern: layoutSystem.gridPattern || 'Responsive grid (3-col desktop, 1-col mobile)',
+  layoutStructure: resolvedLayout.structure,
+  spacingTokens: resolvedLayout.spacingScale.join(', ') + 'px',
+  containerMaxWidth: resolvedLayout.maxWidth,
+  gridPattern: resolvedLayout.gridPattern || 'Responsive grid (3-col desktop, 1-col mobile)',
 
-  illustrationStyle: illustrationStyle,
-  motionNotes: motionNotes,
+  illustrationStyle: resolvedIllustration,
+  motionNotes: resolvedMotion,
+  confidenceNotes,
+  evidenceTrail,
 };
+
+applyBlendMetadata(referenceAssets, evidencePacks);
 ```
+
+> ✅ **Always annotate defaults with `confidenceNotes`** explaining whether they came from Chrome MCP evidence (high confidence), blended inference (medium), or SaaS fallback (low). Surface the `evidenceTrail` so downstream tasks can cite the exact source of each token.
 
 ### Step 3: Generate Per-Screen Prompts
 
@@ -164,6 +188,9 @@ journeySteps.forEach((step, index) => {
     grid_pattern: visualSystem.gridPattern,
     illustration_style: visualSystem.illustrationStyle,
     motion_notes: visualSystem.motionNotes,
+    confidence_notes: visualSystem.confidenceNotes,
+    evidence_trail: visualSystem.evidenceTrail,
+    reference_blend_summary: blendSummary.blendNotes,
 
     // Reference Assets (passed as array for template loop)
     reference_assets: (referenceAssets || []).map((asset) => ({
@@ -173,6 +200,9 @@ journeySteps.forEach((step, index) => {
       elements_to_avoid: asset.elementsToAvoid,
       css_extracted: !!asset.cssVariables,
       css_tokens: formatCSSTokens(asset.cssVariables),
+      token_weight: asset.tokenWeight,
+      typography_pairs: asset.typographyPairs,
+      evidence_confidence: asset.evidenceConfidence,
     })),
 
     // UI Requirements
@@ -225,6 +255,248 @@ function formatCSSTokens(cssVars) {
     .map(([key, value]) => `${key}: ${value}`)
     .join(', ');
 }
+
+function collectEvidence({ chromeMcpEvidence, referenceAssets, discoveryDefaults }) {
+  const packs = [];
+
+  if (Array.isArray(chromeMcpEvidence)) {
+    chromeMcpEvidence.forEach((artifact) => {
+      packs.push({
+        source: artifact.sourceUrl || artifact.file,
+        type: 'chrome-mcp',
+        cssVariables: artifact.cssVariables,
+        palette: artifact.palette,
+        typography: artifact.typography,
+        spacingScale: artifact.spacingScale,
+      });
+    });
+  }
+
+  (referenceAssets || []).forEach((asset) => {
+    packs.push({
+      source: asset.sourceUrl || asset.description,
+      type: asset.cssVariables ? 'reference-css' : 'reference-manual',
+      cssVariables: asset.cssVariables,
+      palette: asset.palette,
+      typography: asset.typography,
+      spacingScale: asset.spacingScale,
+    });
+  });
+
+  if (!packs.length) {
+    return {
+      packs: [
+        {
+          source: 'SaaS default pack',
+          type: 'fallback',
+          cssVariables: discoveryDefaults?.brandPalette?.cssVariables,
+          palette: discoveryDefaults?.brandPalette,
+          typography: discoveryDefaults?.typography,
+          spacingScale: discoveryDefaults?.layoutSystem?.spacingScale,
+          layoutSystem: discoveryDefaults?.layoutSystem,
+        },
+      ],
+      summary: summarizeBlend([], discoveryDefaults),
+    };
+  }
+
+  return {
+    packs,
+    summary: summarizeBlend(packs, discoveryDefaults),
+  };
+}
+
+function synthesizePreset(packs, blendSummary) {
+  const weights = {};
+  const paletteAccumulator = {};
+  const typographyAccumulator = {};
+  const spacingAccumulator = {};
+
+  packs.forEach((pack) => {
+    const baseWeight = pack.type === 'chrome-mcp' ? 3 : pack.type === 'reference-css' ? 2 : 1;
+    Object.entries(pack.palette || {}).forEach(([token, value]) => {
+      const key = value.toLowerCase();
+      paletteAccumulator[key] = (paletteAccumulator[key] || 0) + baseWeight;
+      weights[token] = weights[token] || {};
+      weights[token][key] = (weights[token][key] || 0) + baseWeight;
+    });
+
+    (pack.typography?.pairings || []).forEach((pair) => {
+      const key = `${pair.heading}|${pair.body}`.toLowerCase();
+      typographyAccumulator[key] = (typographyAccumulator[key] || 0) + baseWeight;
+    });
+
+    (pack.spacingScale || []).forEach((value) => {
+      const key = `${value}px`;
+      spacingAccumulator[key] = (spacingAccumulator[key] || 0) + baseWeight;
+    });
+  });
+
+  const resolvedPalette = resolvePalette(weights, paletteAccumulator);
+  const resolvedTypography = resolveTypography(typographyAccumulator, packs);
+  const resolvedLayout = resolveLayout(spacingAccumulator, packs);
+
+  const evidenceTrail = packs.map((pack) => ({
+    source: pack.source,
+    type: pack.type,
+    contributedTokens: Object.keys(pack.cssVariables || {}),
+  }));
+
+  const confidenceNotes = buildConfidence(
+    resolvedPalette,
+    resolvedTypography,
+    resolvedLayout,
+    packs,
+  );
+
+  return {
+    brandPalette: resolvedPalette,
+    typography: resolvedTypography,
+    layoutSystem: resolvedLayout,
+    illustrationStyle: blendSummary?.illustrationStyle || 'Clean SaaS with contextual accents',
+    motionNotes: blendSummary?.motionNotes || 'Subtle micro-interactions (200ms easing)',
+    confidenceNotes,
+    evidenceTrail,
+  };
+}
+
+function summarizeBlend(packs, discoveryDefaults) {
+  if (!packs.length) {
+    return {
+      illustrationStyle: discoveryDefaults?.illustrationStyle || 'Clean SaaS illustration',
+      motionNotes: discoveryDefaults?.motionNotes || 'Default SaaS interactions',
+      blendNotes: 'No Chrome MCP evidence found — SaaS defaults applied.',
+    };
+  }
+
+  const recurringSources = packs
+    .filter((pack) => pack.type !== 'fallback')
+    .map((pack) => pack.source)
+    .join(', ');
+
+  return {
+    illustrationStyle:
+      packs.find((pack) => pack.illustrationStyle)?.illustrationStyle ||
+      discoveryDefaults?.illustrationStyle,
+    motionNotes:
+      packs.find((pack) => pack.motionNotes)?.motionNotes || discoveryDefaults?.motionNotes,
+    blendNotes: `Synthesized from ${recurringSources || 'SaaS defaults'}`,
+  };
+}
+
+function formatCssBlock(...tokenGroups) {
+  return tokenGroups
+    .filter(Boolean)
+    .flatMap((group) => Object.entries(group))
+    .map(([key, value]) => `${key}: ${value};`)
+    .join('\n');
+}
+
+function resolvePalette(tokenWeights, paletteAccumulator) {
+  const resolved = { primary: '#2563EB', accent: '#F97316', neutral: '#1F2937', cssVariables: {} };
+  Object.entries(tokenWeights).forEach(([token, values]) => {
+    const [winner] = Object.entries(values).sort((a, b) => b[1] - a[1])[0] || [];
+    if (winner) {
+      resolved[token] = winner.toUpperCase();
+      resolved.cssVariables[`--color-${token}`] = winner;
+    }
+  });
+
+  if (!Object.keys(resolved.cssVariables).length && Object.keys(paletteAccumulator).length) {
+    const [fallback] = Object.entries(paletteAccumulator).sort((a, b) => b[1] - a[1])[0];
+    resolved.primary = fallback[0].toUpperCase();
+    resolved.cssVariables['--color-primary'] = fallback[0];
+  }
+
+  return resolved;
+}
+
+function resolveTypography(typographyAccumulator, packs) {
+  const resolved = {
+    headingFont: 'Inter, sans-serif',
+    bodyFont: 'Inter, sans-serif',
+    scale: { body: '16px', subtitle: '18px', heading: '28px' },
+    cssVariables: {
+      '--font-heading': '"Inter", sans-serif',
+      '--font-body': '"Inter", sans-serif',
+    },
+  };
+
+  const [pair] = Object.entries(typographyAccumulator).sort((a, b) => b[1] - a[1])[0] || [];
+  if (pair) {
+    const [heading, body] = pair.split('|');
+    resolved.headingFont = heading;
+    resolved.bodyFont = body;
+    resolved.cssVariables['--font-heading'] = heading;
+    resolved.cssVariables['--font-body'] = body;
+  }
+
+  const scaleSource = packs.find(
+    (pack) => Array.isArray(pack.spacingScale) && pack.typography?.scale,
+  );
+  if (scaleSource?.typography?.scale) {
+    resolved.scale = scaleSource.typography.scale;
+  }
+
+  return resolved;
+}
+
+function resolveLayout(spacingAccumulator, packs) {
+  const resolved = {
+    structure: 'Responsive cards with generous whitespace',
+    spacingScale: [8, 16, 24, 32, 48, 64],
+    maxWidth: '1200px',
+    cssVariables: { '--space-base': '8px' },
+  };
+
+  const weightedSpacing = Object.entries(spacingAccumulator).sort((a, b) => b[1] - a[1]);
+  if (weightedSpacing.length) {
+    resolved.spacingScale = weightedSpacing.slice(0, 6).map(([value]) => parseInt(value, 10));
+    resolved.cssVariables['--space-base'] = weightedSpacing[0][0];
+  }
+
+  const layoutSource = packs.find((pack) => pack.layoutSystem);
+  if (layoutSource?.layoutSystem) {
+    Object.assign(resolved, layoutSource.layoutSystem);
+  }
+
+  return resolved;
+}
+
+function buildConfidence(resolvedPalette, resolvedTypography, resolvedLayout, packs) {
+  const highConfidence = packs.some((pack) => pack.type === 'chrome-mcp');
+  const mediumConfidence = packs.some((pack) => pack.type === 'reference-css');
+
+  if (highConfidence) {
+    return `High confidence: palette + typography pulled directly from Chrome MCP evidence (${packs
+      .filter((pack) => pack.type === 'chrome-mcp')
+      .map((pack) => pack.source)
+      .join(', ')}).`;
+  }
+
+  if (mediumConfidence) {
+    return `Medium confidence: blended recurring tokens from reference URLs (${packs
+      .filter((pack) => pack.type === 'reference-css')
+      .map((pack) => pack.source)
+      .join(', ')}). Override if brand guidance differs.`;
+  }
+
+  return 'Low confidence: SaaS defaults applied. Provide brand tokens or rerun Chrome MCP extraction to improve fidelity.';
+}
+
+function applyBlendMetadata(referenceAssets, packs) {
+  if (!Array.isArray(referenceAssets)) return;
+
+  referenceAssets.forEach((asset) => {
+    const pack = packs.find((item) => item.source === (asset.sourceUrl || asset.description));
+    if (!pack) return;
+    const baseWeight = pack.type === 'chrome-mcp' ? 3 : pack.type === 'reference-css' ? 2 : 1;
+    asset.tokenWeight = baseWeight;
+    asset.typographyPairs = pack.typography?.pairings || [];
+    asset.evidenceConfidence =
+      pack.type === 'chrome-mcp' ? 'high' : pack.type === 'reference-css' ? 'medium' : 'low';
+  });
+}
 ```
 
 ### Step 4: Compile Prompts Document
@@ -273,6 +545,15 @@ Create `docs/ui/ui-designer-screen-prompts.md` with all prompts:
 - Illustrations: {{illustration_style}}
 - Motion: {{motion_notes}}
 
+### Confidence & Evidence
+
+- Notes: {{confidence_notes}}
+- Reference blend: {{reference_blend_summary}}
+- Evidence trail:
+  {{#each evidence_trail}}
+  - {{type}} → {{source}} ({{contributedTokens.length}} tokens)
+    {{/each}}
+
 ---
 
 ## Per-Screen Prompts
@@ -314,6 +595,16 @@ Create `docs/ui/ui-designer-screen-prompts.md` with all prompts:
 - **{{sourceType}}**: {{sourceUrl}}
   - Keep: {{elementsToKeep}}
   - Avoid: {{elementsToAvoid}}
+  - Confidence: {{evidenceConfidence}} (weight: {{tokenWeight}})
+  {{#if typography_pairs}}
+  - Typography pairs reinforcing defaults:
+    {{#each typography_pairs}}
+    - {{this.heading}} × {{this.body}}
+    {{/each}}
+  {{/if}}
+  {{#if cssExtracted}}
+  - CSS extracted: ✅ (see tokens above)
+  {{/if}}
 {{/each}}
 
 ---
@@ -391,6 +682,12 @@ This brief supports the single-shot workflow. For the **conversational designer 
 ✅ Color palette: {{brand_palette.primary}}, {{brand_palette.accent}}, {{brand_palette.neutral}}
 ✅ Typography: {{typography.headingFont}} / {{typography.bodyFont}}
 ✅ Layout: {{layoutSystem.structure}}
+🔎 Confidence: {{confidence_notes}}
+🔗 Evidence sources:
+{{#each evidence_trail}}
+  - {{type}} → {{source}} ({{contributedTokens.length}} tokens)
+{{/each}}
+🧪 Reference blend: {{reference_blend_summary}}
 
 **Next Steps:**
 
@@ -421,12 +718,13 @@ All context from discovery is reused:
 
 **If discovery state is incomplete:**
 
-1. Use PRD/UX spec to infer missing context
-2. Apply sensible defaults for modern SaaS
-3. Warn user about inferred values
-4. Suggest re-running discovery for better prompts
+1. Inspect `chromeMcpEvidence` + `referenceAssets[].chromeMcpArtifacts`.
+2. Weight Chrome MCP artifacts highest, CSS extraction mid, manual notes lowest.
+3. Blend recurring tokens, typography pairings, and spacing before suggesting defaults.
+4. Emit `confidenceNotes` + `evidenceTrail`, highlighting any low-confidence fields.
+5. If **no evidence packs** remain, clearly warn the user and then apply SaaS presets.
 
-**Default Visual System (if missing):**
+**SaaS Fallback (evidence not found):**
 
 ```javascript
 {

--- a/aidesigner-core/tasks/record-ui-designer-selection.md
+++ b/aidesigner-core/tasks/record-ui-designer-selection.md
@@ -199,12 +199,50 @@ Should I include these tokens in your selection record? They'll help developers 
     },
     extractedPalette: ["#1E40AF", "#F59E0B", "#6B7280"],
     extractedTypography: "Inter sans-serif, 14-24px scale",
-    extractedSpacing: "8px base grid (8, 16, 24, 32, 48, 64)"
+    extractedSpacing: "8px base grid (8, 16, 24, 32, 48, 64)",
+    evidenceConfidence: "high"
   }
 }
 ```
 
-#### 1.7 Implementation Guidance
+#### 1.7 Dynamic Default Confidence (NEW)
+
+**Explain where the defaults came from.** Capture the synthesized preset emitted during prompt generation so downstream teams know which evidence informed each token.
+
+**Liaison Message:**
+
+```
+I'm going to log the inferred defaults that shaped your prompts.
+
+Can you confirm if these confidence notes & evidence sources look correct?
+
+- Confidence: [e.g., "High confidence: Chrome MCP evidence from https://linear.app"]
+- Reference blend: [e.g., "Synthesized from https://linear.app, https://cal.com"]
+- Evidence trail: [List each source + token count]
+
+If you'd like to override any token (colors, fonts, spacing), let me know so I can update the record.
+```
+
+**Capture:**
+
+```javascript
+{
+  inferredDefaults: {
+    confidenceNotes: "High confidence: Chrome MCP evidence from https://linear.app",
+    referenceBlend: "Synthesized from https://linear.app, https://cal.com",
+    evidenceTrail: [
+      { source: "https://linear.app", type: "chrome-mcp", contributedTokens: ["--color-primary", "--font-heading"] },
+      { source: "https://cal.com", type: "reference-css", contributedTokens: ["--color-accent"] }
+    ],
+    overrides: {
+      colors: { primary: "#1E3A8A" },
+      typography: { headingFont: "Sohne", bodyFont: "Inter" }
+    }
+  }
+}
+```
+
+#### 1.8 Implementation Guidance
 
 **Liaison Message:**
 
@@ -286,11 +324,21 @@ This document tracks visual concept explorations generated with Google Nano Bana
 --space-md: 16px;
 --space-lg: 32px;
 ```
+
+**Evidence Confidence**: [High / Medium / Low]
 ````
 
 **Palette**: #1E40AF, #F59E0B, #6B7280
 **Typography**: Inter sans-serif, 14-24px scale
 **Spacing**: 8px base grid
+
+### Dynamic Defaults & Evidence (NEW)
+
+- **Confidence Notes**: [Why the defaults are trusted]
+- **Reference Blend**: [Summary of sources that influenced defaults]
+- **Evidence Trail**:
+  - [Type → Source (tokens contributed)]
+- **Overrides Applied**: [Any manual adjustments from user/stakeholder]
 
 ### Reference Assets (NEW - Enhanced)
 
@@ -383,7 +431,21 @@ Call the MCP `recordDecision` tool/method with the **enhanced schema**:
     },
     extractedPalette: ["#1E40AF", "#F59E0B", "#6B7280"],
     extractedTypography: "Inter sans-serif, 14-24px scale",
-    extractedSpacing: "8px base grid"
+    extractedSpacing: "8px base grid",
+    evidenceConfidence: "high"
+  },
+
+  inferredDefaults: {
+    confidenceNotes: "High confidence: Chrome MCP evidence from https://linear.app",
+    referenceBlend: "Synthesized from https://linear.app, https://cal.com",
+    evidenceTrail: [
+      { source: "https://linear.app", type: "chrome-mcp", contributedTokens: ["--color-primary", "--font-heading"] },
+      { source: "https://cal.com", type: "reference-css", contributedTokens: ["--color-accent"] }
+    ],
+    overrides: {
+      colors: { primary: "#1E3A8A" },
+      typography: { headingFont: "Sohne", bodyFont: "Inter" }
+    }
   },
 
   // Differentiators & guidance

--- a/docs/COMPLETE-WORKFLOW.md
+++ b/docs/COMPLETE-WORKFLOW.md
@@ -439,6 +439,12 @@ When you share an inspiration URL:
 4. AI presents extracted tokens for your refinement
 5. Refined tokens lock into all generated outputs
 
+### Evidence-Driven Defaults
+
+- **Weighted blending:** Chrome MCP captures contribute the highest weight when synthesizing palettes and typography. CSS-only references provide medium weight, and manual descriptions provide baseline weight. The resulting preset includes confidence notes and a full evidence trail.
+- **Fallback transparency:** If no Chrome MCP artifacts are found, the workflow still blends provided inspiration but marks the defaults as low confidence so engineering knows they were inferred. Once real evidence is available, rerun the prompt task to refresh the defaults.
+- **Override anytime:** Provide overrides (e.g., "Use brand primary #0052CC") and the system updates both the prompts and the downstream Nano Banana selection log while preserving the evidence history.
+
 ---
 
 ## What Gets Created

--- a/docs/guides/CONVERSATIONAL_UI_DESIGNER.md
+++ b/docs/guides/CONVERSATIONAL_UI_DESIGNER.md
@@ -307,7 +307,7 @@ Nana: "No problem! We'll define your visual language from scratch
 ### Stage 4: Visual Language Confirmation
 
 **What Happens:**
-Nana presents a complete visual system based on your inspiration or sensible defaults, and asks for confirmation.
+Nana synthesizes a visual system by first mining Chrome MCP evidence (CSS variables, palette clusters, typography pairings) gathered during discovery. When multiple references are provided, the liaison weighs recurring tokens—Chrome MCP captures carry the highest weight, CSS-extracted references next, and manual descriptions last—before falling back to any SaaS presets.
 
 ```
 Nana: "Let's lock in your visual design system.
@@ -366,6 +366,8 @@ Confirm or request adjustments
   motionNotes: "Subtle hover lifts (4px), smooth transitions (250ms)"
 }
 ```
+
+> 🧠 **Auto-adaptive defaults:** If Chrome MCP artifacts exist (`docs/ui/chrome-mcp/*.json` or inline evidence packs), Nana uses them to build a context-specific preset and surfaces confidence notes plus an evidence trail. You'll see exactly which URLs influenced each token. If the confidence looks off—or you want to override a color, font, or spacing scale—just state the override and Nana updates the preset before prompt generation.
 
 ---
 
@@ -800,10 +802,13 @@ Nana: [Uses Chrome MCP tools]
 
 ### Fallback Without Chrome MCP
 
-If Chrome MCP isn't available:
+If Chrome MCP isn't available, Nana still blends whatever evidence you provide (manual descriptions, screenshots, UX specs) and will label the resulting defaults with **low confidence** so the team knows they came from inference rather than inspection.
 
 ```
 Nana: "Chrome DevTools MCP isn't enabled. No problem!
+
+       I'll weight recurring colors/typography from your references, but
+       mark them as inferred so engineering can double-check.
 
        Please describe the visual elements from [URL]:
        - Primary colors (hex codes if you have them)
@@ -811,7 +816,7 @@ Nana: "Chrome DevTools MCP isn't enabled. No problem!
        - Spacing patterns you like"
 ```
 
-Manual input is captured in the same format.
+Manual input is captured in the same format and annotated as `evidenceConfidence: low`. When you later supply real Chrome MCP captures, re-run the prompt task to refresh the defaults with high-confidence tokens.
 
 ---
 


### PR DESCRIPTION
## Summary
- teach the UI prompt task to hydrate quick-lane defaults from Chrome MCP evidence, blend multi-source tokens, and emit confidence metadata
- extend the selection logging task to record synthesized defaults, evidence trails, and override history for Nano Banana deliverables
- update conversational UI designer documentation to explain auto-adapting defaults, weighted blending, and manual override guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e35fcde12c8326b80a04013d043826