### PR TITLE
fix: add validation guards for palette and typography synthesis

### DIFF
--- a/aidesigner-core/tasks/generate-ui-designer-prompt.md
+++ b/aidesigner-core/tasks/generate-ui-designer-prompt.md
@@ -321,6 +321,7 @@ function synthesizePreset(packs, blendSummary) {
   packs.forEach((pack) => {
     const baseWeight = pack.type === 'chrome-mcp' ? 3 : pack.type === 'reference-css' ? 2 : 1;
     Object.entries(pack.palette || {}).forEach(([token, value]) => {
+      if (typeof value !== 'string' || !value.trim()) return;
       const key = value.toLowerCase();
       paletteAccumulator[key] = (paletteAccumulator[key] || 0) + baseWeight;
       weights[token] = weights[token] || {};
@@ -328,6 +329,7 @@ function synthesizePreset(packs, blendSummary) {
     });
 
     (pack.typography?.pairings || []).forEach((pair) => {
+      if (!pair.heading || !pair.body) return;
       const key = `${pair.heading}|${pair.body}`.toLowerCase();
       typographyAccumulator[key] = (typographyAccumulator[key] || 0) + baseWeight;
     });
@@ -442,9 +444,7 @@ function resolveTypography(typographyAccumulator, packs) {
     resolved.cssVariables['--font-body'] = body;
   }
 
-  const scaleSource = packs.find(
-    (pack) => Array.isArray(pack.spacingScale) && pack.typography?.scale,
-  );
+  const scaleSource = packs.find((pack) => pack.typography?.scale);
   if (scaleSource?.typography?.scale) {
     resolved.scale = scaleSource.typography.scale;
   }


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #145 based on CodeRabbit review feedback.

## Changes

- Add string validation guard for palette ingestion to prevent errors with nested objects
- Remove spacing requirement for typography scale adoption to accept Chrome MCP evidence
- Add validation for typography pairings to ensure heading and body fonts exist

## Related

- Original PR: #145
- Addresses CodeRabbit review comments from 2025-10-06

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preset generation robustness by ignoring empty or non-string palette values.
  * Skips incomplete typography pairings to prevent invalid configurations.
  * More reliable typography scale selection by choosing the first available defined scale across packs, reducing edge-case failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->