### PR TITLE
Add end-to-end persona simulation for AiDesigner

### DIFF
--- a/docs/user-persona-simulation.md
+++ b/docs/user-persona-simulation.md
@@ -1,0 +1,150 @@
+---
+title: 'Persona Simulation: Freelance UX Researcher Using AiDesigner'
+status: draft
+last_updated: 2024-04-09
+contributors:
+  - gpt-5-codex
+summary: |
+  End-to-end simulation illustrating how a freelance UX researcher ideates a mobile
+  wellness companion, collaborates with AiDesigner, validates orchestrated agent
+  hand-offs, and extracts a production-ready Gemini prompt plus lightweight UI maquette.
+---
+
+# Scenario Overview
+
+- **Persona**: _Maya Chen_, 33-year-old freelance UX researcher and product strategist.
+- **Goal**: Prototype a personalized mindfulness companion app for busy remote workers in under two hours.
+- **Environment**: Maya uses the AiDesigner web interface on a laptop, backed by the invisible orchestrator coordinating planning, research, and UI agents.
+- **Success Criteria**:
+  - A validated product direction and interaction flow.
+  - A prompt Maya can reuse with Gemini (or any LLM-based UI generator) to create high-fidelity mockups.
+  - Confidence that orchestrated agents responded correctly at each phase.
+
+# Stage 0 – Idea Intake
+
+| Actor            | Action                                                                                                               | System Notes                                                                 |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Maya             | Enters natural-language brief: _“I want a mindfulness companion that fits micro-breaks into a remote worker’s day.”_ | Invisible Orchestrator logs a new session, routes message to Phase Detector. |
+| Phase Detector   | Classifies phase as `Discovery/Problem Framing`.                                                                     | Confidence score 0.81 triggers Research Planner agent.                       |
+| Research Planner | Requests clarifying intents: target habits, metrics for success.                                                     | Prompts are bundled and returned to Maya.                                    |
+
+**Verification**: Phase detection aligns with discovery cues (goal, context). Planner prompts are contextual and avoid implementation bias.
+
+# Stage 1 – Clarifying Dialogues
+
+## Round 1
+
+- **Maya**: “Focus on remote designers, help them decompress in 5-minute intervals, and track mood trends.”
+- **Planner Agent**: Summarizes constraints, requests data sources (journaling, wearables) and tone preferences.
+- **Invisible Orchestrator**: Confirms requirements completeness (coverage score 0.74 < 0.8 threshold) → requests further detail.
+
+## Round 2
+
+- **Maya**: “No wearables. Use calendar and Slack to spot breaks. Tone should feel like a calm colleague.”
+- **Planner Agent**: Recomputes coverage score (0.88). Triggers transition to `Concept Exploration` lane.
+- **System Check**: Handoff handshake logged; UI displays “Discovery Complete ✓”.
+
+**Verification**: Requirements coverage metric increased after additional detail. Lane switch occurs once threshold met.
+
+# Stage 2 – Concept Synthesis
+
+| Step | Responsible Agent            | Output                                                                    | QA                                                               |
+| ---- | ---------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1    | Concept Synthesizer          | Drafts user journey (trigger → micro-coaching → reflection).              | Cross-checked with context slots; no missing persona attributes. |
+| 2    | Ritual Library (domain pack) | Suggests 3 micro-exercises (box breathing, desk stretch, gratitude ping). | Exercises comply with “no wearables” constraint.                 |
+| 3    | UX Writer                    | Crafts notification copy in “calm colleague” tone.                        | Tone analysis score 0.92 (target ≥ 0.9).                         |
+| 4    | Orchestrator                 | Bundles outputs into `Concept Packet v1`.                                 | Packet validated, passed to Maya via UI.                         |
+
+# Stage 3 – Conversational Review
+
+**Maya**: Requests assurance about data privacy and analytics transparency.
+
+**Trust & Compliance Agent**:
+
+- Produces privacy stance summary.
+- Suggests transparent consent flow and anonymized mood analytics.
+- Flags need for legal review before launch.
+
+**Verification**: Compliance agent triggered because conversation touched on data governance keywords; ensures coverage before build handoff.
+
+# Stage 4 – UI Exploration Prompt
+
+The system now prepares a Gemini-ready prompt derived from the validated concept packet.
+
+```text
+You are Gemini, acting as a senior product designer. Create three high-fidelity mobile screens for a “Quiet Quarters” mindfulness companion targeting remote product designers.
+
+Context:
+- Sessions last 5 minutes, inserted between calendar gaps or after Slack focus sessions.
+- Interface tone: calm colleague, warm neutrals with subtle gradients.
+- Key screens: (1) Home dashboard with upcoming micro-break prompt, (2) Active session with animated breathing coach and skip/reschedule controls, (3) Reflection screen showing mood trend chart for the week.
+- Integrations: Google Calendar read access, Slack status detection. No wearable data.
+- Accessibility: large tap targets, optional voice guidance toggle, WCAG AA contrast.
+
+Deliverables:
+- Component list and layout rationale.
+- Microcopy for notifications and empty states.
+- Suggestions for motion design to reinforce calmness.
+```
+
+**Verification**: Prompt automatically assembled by Prompt Composer agent; cross-references all persona constraints. System confirms Gemini prompt coverage checklist (persona, tone, screens, accessibility, integrations) = 5/5.
+
+# Stage 5 – Low-Fidelity Maquette
+
+Using the `Concept Packet v1`, AiDesigner’s Wireframe Drafting agent returns an ASCII maquette that Maya can refine:
+
+```
++--------------------------------------------------+
+| Quiet Quarters                                    |
+| 08:55 next pause in 5m • “Prep your mind for UX review”
+|--------------------------------------------------|
+| [Take 5 Now]    [Snooze 10]                      |
+|--------------------------------------------------|
+| Mood trend this week                              |
+|  Mon  Tue  Wed  Thu  Fri                         |
+|   🙂    🙂    😐    🙂    😀                      |
+|--------------------------------------------------|
+| Tip of the day: Box breathing with visual timer  |
++--------------------------------------------------+
+```
+
+```
++------------------------------+
+| Breathe with Cole (2:45 left)|
+|   ◯ expanding ring animation |
+|------------------------------|
+|  Inhale ▸▸▸                  |
+|  Hold ▸▸▸                   |
+|  Exhale ▸▸▸                 |
+|------------------------------|
+|  [Pause]    [Skip]   [Voice ✓]|
++------------------------------+
+```
+
+```
++----------------------------------------+
+| How did the breaks help today?         |
+|----------------------------------------|
+| Mood slider: 😟 ---◉---- 😀             |
+| Notes field: “What made the biggest diff?”|
+|----------------------------------------|
+| Trend insight: “Evening breaks improved |
+| focus by 18% week-over-week.”          |
+|----------------------------------------|
+| [Share summary]    [Schedule tomorrow] |
++----------------------------------------+
+```
+
+**Verification**: Wireframe adheres to stated requirements (no wearable references, calm copy, accessible controls). QA checklist marks `Layout`, `Tone`, and `Accessibility` as pass; `Visual polish` intentionally pending.
+
+# Stage 6 – Wrap-Up & Next Steps
+
+1. **Session Summary**: Orchestrator compiles transcript, decisions, outstanding risks (legal review) into a downloadable brief.
+2. **Handoff Guidance**: Suggests running the Gemini prompt plus maquette through a design tool (Figma) and scheduling stakeholder review.
+3. **Retro Capture**: Maya leaves feedback; satisfaction score 4.5/5 stored for model fine-tuning.
+
+# Key Takeaways
+
+- The simulation validates multi-agent collaboration from idea capture through UI artifacts.
+- Automated metrics (phase confidence, coverage, tone analysis) show the guardrails functioning.
+- Deliverables (Gemini prompt, ASCII maquette) equip the persona to continue in her preferred tools without manual rewriting.


### PR DESCRIPTION
## Summary
- add a markdown case study simulating a freelance UX researcher using AiDesigner
- document each orchestrated phase from idea intake to UI artifact delivery
- include a reusable Gemini prompt and ASCII maquettes for the simulated app

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3e649d44883268af8e5cfff51ea9a