### PR TITLE
Harden Shadcn codegen output path and fix docs

### DIFF
--- a/.dev/config/test/support/ts-transformer.js
+++ b/.dev/config/test/support/ts-transformer.js
@@ -1,15 +1,17 @@
 const crypto = require('node:crypto');
 const ts = require('typescript');
 
+const compilerOptions = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
 module.exports = {
   process(sourceText, sourcePath) {
     const { outputText } = ts.transpileModule(sourceText, {
       fileName: sourcePath,
-      compilerOptions: {
-        module: ts.ModuleKind.CommonJS,
-        target: ts.ScriptTarget.ES2020,
-        esModuleInterop: true,
-      },
+      compilerOptions,
     });
 
     return { code: outputText };
@@ -17,7 +19,7 @@ module.exports = {
   getCacheKey(sourceText, sourcePath) {
     return crypto
       .createHash('md5')
-      .update(sourceText + sourcePath)
+      .update(sourceText + '\0' + sourcePath + '\0' + JSON.stringify(compilerOptions))
       .digest('hex');
   },
 };

--- a/.dev/config/test/support/ts-transformer.js
+++ b/.dev/config/test/support/ts-transformer.js
@@ -1,5 +1,23 @@
-const { createTransformer } = require('babel-jest').default;
+const crypto = require('node:crypto');
+const ts = require('typescript');
 
-module.exports = createTransformer({
-  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
-});
+module.exports = {
+  process(sourceText, sourcePath) {
+    const { outputText } = ts.transpileModule(sourceText, {
+      fileName: sourcePath,
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2020,
+        esModuleInterop: true,
+      },
+    });
+
+    return { code: outputText };
+  },
+  getCacheKey(sourceText, sourcePath) {
+    return crypto
+      .createHash('md5')
+      .update(sourceText + sourcePath)
+      .digest('hex');
+  },
+};

--- a/.dev/test/build-shadcn-page.test.js
+++ b/.dev/test/build-shadcn-page.test.js
@@ -44,7 +44,7 @@ describe('buildShadcnPage', () => {
 
   it('rejects attempts to escape the project root', async () => {
     await expect(buildShadcnPage(tokens, {}, path.join('..', 'outside-output'))).rejects.toThrow(
-      'Invalid output directory',
+      'Invalid output directory: path traversal detected',
     );
   });
 });

--- a/.dev/test/build-shadcn-page.test.js
+++ b/.dev/test/build-shadcn-page.test.js
@@ -1,0 +1,50 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { buildShadcnPage } = require('../../packages/codegen/src/react-shadcn');
+
+describe('buildShadcnPage', () => {
+  const projectRoot = process.cwd();
+  const relativeTempDir = path.join('tmp-shadcn-tests');
+  const absoluteTempDir = path.join(projectRoot, relativeTempDir);
+
+  const tokens = {
+    meta: { source: 'url', url: 'https://example.com', capturedAt: '2024-01-01T00:00:00.000Z' },
+    primitives: {
+      color: { 'base/fg': '#111111', 'base/bg': '#ffffff' },
+      font: { sans: { family: 'Inter', weights: [400, 600] } },
+      space: {},
+    },
+    semantic: {},
+  };
+
+  beforeEach(async () => {
+    await fs.rm(absoluteTempDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(absoluteTempDir, { recursive: true, force: true });
+  });
+
+  it('writes generated files within the project directory', async () => {
+    const outputDir = path.join(relativeTempDir, 'valid-output');
+
+    await buildShadcnPage(tokens, {}, outputDir);
+
+    const pagePath = path.join(absoluteTempDir, 'valid-output', 'page.tsx');
+    const stylesPath = path.join(absoluteTempDir, 'valid-output', 'globals.css');
+
+    const pageContent = await fs.readFile(pagePath, 'utf-8');
+    const stylesContent = await fs.readFile(stylesPath, 'utf-8');
+
+    expect(pageContent).toContain('AiDesigner POC');
+    expect(pageContent).toContain('<main');
+    expect(stylesContent).toContain(`--fg:${tokens.primitives.color['base/fg']}`);
+    expect(stylesContent).toContain(`font-family:${tokens.primitives.font.sans.family}`);
+  });
+
+  it('rejects attempts to escape the project root', async () => {
+    await expect(buildShadcnPage(tokens, {}, path.join('..', 'outside-output'))).rejects.toThrow(
+      'Invalid output directory',
+    );
+  });
+});

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -30,7 +30,7 @@ graph TD
     F --> F2{"UX Required?"}
     F2 -->|Yes| F3["UX Expert: Create Front End Spec"]
     F2 -->|No| H["Architect: Create Architecture from PRD"]
-    F3 --> F4["UX Expert: Generate UI Prompt for Lovable/Vaidesigner (Optional)"]
+    F3 --> F4["UX Expert: Generate UI Prompt for Lovable/AiDesigner (Optional)"]
     F4 --> H2["Architect: Create Architecture from PRD + UX Spec"]
     H --> Q{"Early Test Strategy? (Optional)"}
     H2 --> Q
@@ -46,30 +46,30 @@ graph TD
     N --> O["PO: Shard Documents"]
     O --> P["Ready for SM/Dev Cycle"]
 
-    style A fill:#f5f5f5,color:#aidesigneraidesigneraidesigner
-    style B fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style C fill:#e8f5e9,color:#aidesigneraidesigneraidesigner
-    style C2 fill:#e8f5e9,color:#aidesigneraidesigneraidesigner
-    style C3 fill:#e8f5e9,color:#aidesigneraidesigneraidesigner
-    style D fill:#e8f5e9,color:#aidesigneraidesigneraidesigner
-    style E fill:#fff3eaidesigner,color:#aidesigneraidesigneraidesigner
-    style E2 fill:#fff3eaidesigner,color:#aidesigneraidesigneraidesigner
-    style F fill:#fff3eaidesigner,color:#aidesigneraidesigneraidesigner
-    style F2 fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style F3 fill:#e1f5fe,color:#aidesigneraidesigneraidesigner
-    style F4 fill:#e1f5fe,color:#aidesigneraidesigneraidesigner
-    style G fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style H fill:#f3e5f5,color:#aidesigneraidesigneraidesigner
-    style H2 fill:#f3e5f5,color:#aidesigneraidesigneraidesigner
-    style Q fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style R fill:#ffd54f,color:#aidesigneraidesigneraidesigner
-    style I fill:#f9abaidesigneraidesigner,color:#fff
-    style J fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
+    style A fill:#f5f5f5,color:#1f2933
+    style B fill:#e3f2fd,color:#1f2933
+    style C fill:#e8f5e9,color:#1f2933
+    style C2 fill:#e8f5e9,color:#1f2933
+    style C3 fill:#e8f5e9,color:#1f2933
+    style D fill:#e8f5e9,color:#1f2933
+    style E fill:#fff3e0,color:#1f2933
+    style E2 fill:#fff3e0,color:#1f2933
+    style F fill:#fff3e0,color:#1f2933
+    style F2 fill:#e3f2fd,color:#1f2933
+    style F3 fill:#e1f5fe,color:#1f2933
+    style F4 fill:#e1f5fe,color:#1f2933
+    style G fill:#e3f2fd,color:#1f2933
+    style H fill:#f3e5f5,color:#1f2933
+    style H2 fill:#f3e5f5,color:#1f2933
+    style Q fill:#e3f2fd,color:#1f2933
+    style R fill:#ffd54f,color:#1f2933
+    style I fill:#f9ab91,color:#fff
+    style J fill:#e3f2fd,color:#1f2933
     style K fill:#34a853,color:#fff
-    style L fill:#f9abaidesigneraidesigner,color:#fff
-    style M fill:#fff3eaidesigner,color:#aidesigneraidesigneraidesigner
+    style L fill:#f9ab91,color:#fff
+    style M fill:#fff3e0,color:#1f2933
     style N fill:#1a73e8,color:#fff
-    style O fill:#f9abaidesigneraidesigner,color:#fff
+    style O fill:#f9ab91,color:#fff
     style P fill:#34a853,color:#fff
 ```
 
@@ -154,31 +154,31 @@ graph TD
     Z --> K["Mark Story as Done"]
     K --> B
 
-    style A fill:#f5f5f5,color:#aidesigneraidesigneraidesigner
-    style B fill:#e8f5e9,color:#aidesigneraidesigneraidesigner
-    style B2 fill:#e8f5e9,color:#aidesigneraidesigneraidesigner
-    style S fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style T fill:#ffd54f,color:#aidesigneraidesigneraidesigner
-    style U fill:#ffd54f,color:#aidesigneraidesigneraidesigner
-    style B3 fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style B4 fill:#fce4ec,color:#aidesigneraidesigneraidesigner
-    style C fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style D fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style E fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style V fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style W fill:#ffd54f,color:#aidesigneraidesigneraidesigner
-    style X fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style F fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style G fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style H fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style I fill:#f9abaidesigneraidesigner,color:#fff
-    style J fill:#ffd54f,color:#aidesigneraidesigneraidesigner
+    style A fill:#f5f5f5,color:#1f2933
+    style B fill:#e8f5e9,color:#1f2933
+    style B2 fill:#e8f5e9,color:#1f2933
+    style S fill:#e3f2fd,color:#1f2933
+    style T fill:#ffd54f,color:#1f2933
+    style U fill:#ffd54f,color:#1f2933
+    style B3 fill:#e3f2fd,color:#1f2933
+    style B4 fill:#fce4ec,color:#1f2933
+    style C fill:#e3f2fd,color:#1f2933
+    style D fill:#e3f2fd,color:#1f2933
+    style E fill:#e3f2fd,color:#1f2933
+    style V fill:#e3f2fd,color:#1f2933
+    style W fill:#ffd54f,color:#1f2933
+    style X fill:#e3f2fd,color:#1f2933
+    style F fill:#e3f2fd,color:#1f2933
+    style G fill:#e3f2fd,color:#1f2933
+    style H fill:#e3f2fd,color:#1f2933
+    style I fill:#f9ab91,color:#fff
+    style J fill:#ffd54f,color:#1f2933
     style K fill:#34a853,color:#fff
-    style L fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
+    style L fill:#e3f2fd,color:#1f2933
     style M fill:#ff5722,color:#fff
     style N fill:#d32f2f,color:#fff
-    style Y fill:#e3f2fd,color:#aidesigneraidesigneraidesigner
-    style Z fill:#ffd54f,color:#aidesigneraidesigneraidesigner
+    style Y fill:#e3f2fd,color:#1f2933
+    style Z fill:#ffd54f,color:#1f2933
 ```
 
 ## Prerequisites

--- a/packages/codegen/src/react-shadcn.ts
+++ b/packages/codegen/src/react-shadcn.ts
@@ -3,9 +3,11 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 export async function buildShadcnPage(tokens: Tokens, comps: ComponentMap, outDir: string) {
-  // Validate and sanitize output directory
-  const resolvedOutDir = path.resolve(process.cwd(), outDir);
-  if (!resolvedOutDir.startsWith(process.cwd())) {
+  const projectRoot = process.cwd();
+  const resolvedOutDir = path.resolve(projectRoot, outDir);
+  const relativeOutDir = path.relative(projectRoot, resolvedOutDir);
+
+  if (relativeOutDir && (relativeOutDir.startsWith('..') || path.isAbsolute(relativeOutDir))) {
     throw new Error('Invalid output directory: path traversal detected');
   }
   const imports = `import { Button } from "@/components/ui/button"\nimport { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"`;


### PR DESCRIPTION
## Summary
- tighten buildShadcnPage output directory validation using safer path resolution
- switch the Jest TypeScript transformer to use the TypeScript compiler directly and add coverage for buildShadcnPage
- correct the Mermaid diagram typo and invalid color tokens in the user guide

## Testing
- npm test -- build-shadcn-page.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e51e9f1ee483268c9875e176e6839b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Strengthened output path validation to prevent writing outside the project root with clearer error messaging.

- Documentation
  - Updated user guide diagrams with renamed label and improved color/styling for clarity.

- Tests
  - Added integration tests to verify page and stylesheet generation and error handling for invalid output directories.

- Chores
  - Replaced a heavier test transformer with a lightweight, cached transformer for faster, more reliable test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->